### PR TITLE
Use global InvalidArgumentException

### DIFF
--- a/src/Module/DefaultModule.php
+++ b/src/Module/DefaultModule.php
@@ -28,7 +28,7 @@ class DefaultModule extends AbstractModule
             $class = App::classname($module, 'Di/Module');
 
             if (!$class) {
-                throw new InvalidArgumentException('Invalid Di module name: ' . $module);
+                throw new \InvalidArgumentException('Invalid Di module name: ' . $module);
             }
 
             $this->install(new $class);


### PR DESCRIPTION
Without the leading `\`, `DefaultModule` throws `Class 'PipingBag\Module\InvalidArgumentException' not found` when `$class` is false.
