### PR TITLE
use the ViewBuilder if available

### DIFF
--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -61,7 +61,11 @@ class ControllerFactoryFilter extends ParentFactory
         }
 
         $instance = PipingBag::get($className);
-        $instance->viewPath = null;
+        if (method_exists($instance, 'viewBuilder')) {
+            $instance->viewBuilder();
+        } else {
+            $instance->viewPath = null;
+        }
         $instance->name = $controller;
         $instance->setRequest($request);
         $instance->response = $response;


### PR DESCRIPTION
there is no way to actually set `$instance->viewBuilder()->templatePath();` to `null`;
Please close if it is not the correct fix.
