### PR TITLE
ShellDispatcher::run compatible with Cake\Console\ShellDispatcher::run

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -13,10 +13,10 @@ class ShellDispatcher extends BaseShellDispatcher
      * @param array $argv The argv from PHP
      * @return int The exit code of the shell process.
      */
-    public static function run($argv)
+    public static function run($argv, $extra = [])
     {
         $dispatcher = new static($argv);
-        return $dispatcher->dispatch();
+        return $dispatcher->dispatch($extra);
     }
 
     /**


### PR DESCRIPTION
The Cake\Console\ShellDispatcher::run method takes two arguments, an $extra array as the second argument. Overriding this method requires both parameters to be in the method signature. 

This means that using PipingBag Dependency Injection in Shell Classes is not working. The following error is raised: 

```
Declaration of PipingBag\Console\ShellDispatcher::run($argv) should be compatible with 
Cake\Console\ShellDispatcher::run($argv, $extra = Array) in 
[/var/www/xwp/wpcli/vendor/lorenzo/piping-bag/src/Console/ShellDispatcher.php, line 7]
```

Here is a link to the commit in cakePHP with the change:

[https://github.com/cakephp/cakephp/commit/99334977af6114ef21f21ceda22f0a851f9df390](https://github.com/cakephp/cakephp/commit/99334977af6114ef21f21ceda22f0a851f9df390)

It looks like this change was part of CakePHP 3.1.0-RC1.

I added the $extra parameter with default value [], and passed $extra to the ShellDispatcher::dispatch method. 

It would be great if you can merge this change, so that we can use your awesome plugin in our Shell Classes.