### PR TITLE
Add Cache Refresh Command

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -19,6 +19,8 @@ if (!$instance) {
 }
 PipingBag::container($instance);
 
-register_shutdown_function(function () use ($instance, $cache) {
+register_shutdown_function(function () use ($cache) {
+    $instance = PipingBag::container();
+
     Cache::write('pipingbag.instance', $instance, $cache);
 });

--- a/src/Command/PipingBagCacheRefreshCommand.php
+++ b/src/Command/PipingBagCacheRefreshCommand.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Configure;
+use PipingBag\Di\PipingBag;
+
+class PipingBagCacheRefreshCommand extends Command
+{
+    /**
+     * @inheritDoc
+     */
+    public static function defaultName(): string
+    {
+        return 'piping_bag cache refresh';
+    }
+
+    /**
+     * Hook method for defining this command's option parser.
+     *
+     * @see https://book.cakephp.org/4/en/console-commands/option-parsers.html
+     * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
+     * @return \Cake\Console\ConsoleOptionParser The built parser.
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser = parent::buildOptionParser($parser);
+        $parser->setDescription('Refresh the Piping Bag cache');
+
+        return $parser;
+    }
+
+    /**
+     * Implement this method with your command's logic.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return int|null The exit code or null for success
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $modules = Configure::read('PipingBag.modules', []);
+        $instance = PipingBag::create($modules);
+        PipingBag::container($instance);
+
+        return static::CODE_SUCCESS;
+    }
+}


### PR DESCRIPTION
This is useful for things like deploys. You can reset the cache with `bin/cake piping_bag cache refresh`. After running the command a new instance of piping bag container will be cached.